### PR TITLE
Fixed the `invalid name [startcreatedtime]` error

### DIFF
--- a/desktop/libs/liboozie/src/liboozie/oozie_api.py
+++ b/desktop/libs/liboozie/src/liboozie/oozie_api.py
@@ -112,6 +112,9 @@ class OozieApi(object):
     for key, val in filters:
       if key not in OozieApi.VALID_JOB_FILTERS:
         raise ValueError('"%s" is not a valid filter for selecting jobs' % (key,))
+      if key == 'startcreatedtime':
+        params['startcreatedtime'] = val
+        continue
       filter_list.append('%s=%s' % (key, val))
     params['filter'] = ';'.join(filter_list)
 


### PR DESCRIPTION
```
org.apache.oozie.servlet.XServletException: E0420: Invalid jobs filter [user=hue;startcreatedtime=-7d;status=RUNNING;status=PREP;status=SUSPENDED], invalid name [startcreatedtime]
    at org.apache.oozie.servlet.V1JobsServlet.getCoordinatorJobs(V1JobsServlet.java:366)
    at org.apache.oozie.servlet.V1JobsServlet.getJobs(V1JobsServlet.java:156)
    at org.apache.oozie.servlet.BaseJobsServlet.doGet(BaseJobsServlet.java:123)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
    at org.apache.oozie.servlet.JsonRestServlet.service(JsonRestServlet.java:304)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:290)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.oozie.servlet.AuthFilter$2.doFilter(AuthFilter.java:171)
    at org.apache.hadoop.security.authentication.server.AuthenticationFilter.doFilter(AuthenticationFilter.java:615)
    at org.apache.hadoop.security.authentication.server.AuthenticationFilter.doFilter(AuthenticationFilter.java:574)
    at org.apache.oozie.servlet.AuthFilter.doFilter(AuthFilter.java:176)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.oozie.servlet.HostnameFilter.doFilter(HostnameFilter.java:86)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:127)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:293)
    at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:861)
    at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:620)
    at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:489)
    at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.oozie.CoordinatorEngineException: E0420: Invalid jobs filter [user=hue;startcreatedtime=-7d;status=RUNNING;status=PREP;status=SUSPENDED], invalid name [startcreatedtime]
    at org.apache.oozie.CoordinatorEngine.parseJobsFilter(CoordinatorEngine.java:726)
    at org.apache.oozie.CoordinatorEngine.getCoordJobs(CoordinatorEngine.java:624)
    at org.apache.oozie.servlet.V1JobsServlet.getCoordinatorJobs(V1JobsServlet.java:357)
    ... 26 more
```